### PR TITLE
Criar endpoint para o update de task pelo id

### DIFF
--- a/src/controller/task.controller.js
+++ b/src/controller/task.controller.js
@@ -17,6 +17,19 @@ export function TaskController() {
     }
   })
 
+  taskController.put('/task/:taskId', async (req, res, next) => {
+    try {
+      const taskRequest = req.body
+      const { taskId } = req.params
+
+      await taskService.updateTask(taskRequest, taskId)
+
+      res.sendStatus(StatusCodes.OK)
+    } catch (error) {
+      next(error)
+    }
+  })
+
   taskController.get('/task/:userId', async (req, res, next) => {
     try {
       const { userId } = req.params

--- a/src/mappers/task.mapper.js
+++ b/src/mappers/task.mapper.js
@@ -18,7 +18,12 @@ export function TaskMapper() {
     }
   }
 
+  function fromUpdateTaskRequestToTask(task, updateTask) {
+    return { ...task, ...updateTask }
+  }
+
   return {
     fromCreateTaskRequestToTask,
+    fromUpdateTaskRequestToTask,
   }
 }

--- a/src/repository/task.repository.js
+++ b/src/repository/task.repository.js
@@ -17,6 +17,31 @@ export function TaskRepository() {
     }
   }
 
+  async function getTaskById(taskId) {
+    try {
+      const query = 'SELECT * FROM task WHERE id = ? '
+      const params = [taskId]
+
+      return await dataBase.parameterQuery(query, params)
+    } catch (error) {
+      throw error
+    }
+  }
+
+  async function updateTask(updateTaskRequest, taskId) {
+    try {
+      const { title, description, link } = updateTaskRequest
+      const query =
+        'UPDATE task SET title = ?, description = ?, link = ? ' +
+        'WHERE id = ? '
+      const params = [title, description, link, taskId]
+
+      await dataBase.parameterQuery(query, params)
+    } catch (error) {
+      throw error
+    }
+  }
+
   async function getAllTasksByUser(userId) {
     try {
       const query = 'SELECT * FROM task WHERE idUser = ?'
@@ -31,5 +56,7 @@ export function TaskRepository() {
   return {
     getAllTasksByUser,
     createTask,
+    getTaskById,
+    updateTask,
   }
 }

--- a/src/service/task.service.js
+++ b/src/service/task.service.js
@@ -30,8 +30,36 @@ export function TaskService() {
     }
   }
 
+  async function updateTask(updateTaskRequest, taskId) {
+    try {
+      taskValidator.validateUpdateTask(updateTaskRequest, taskId)
+      const task = await getTaskById(taskId)
+
+      if (!task.length) throw new Error('Task não encontrada.')
+
+      const updatetask = taskMapper.fromUpdateTaskRequestToTask(
+        task[0],
+        updateTaskRequest,
+      )
+
+      await taskRepository.updateTask(updatetask, taskId)
+    } catch (error) {
+      throw error
+    }
+  }
+
+  async function getTaskById(taskId) {
+    try {
+      return taskRepository.getTaskById(taskId)
+    } catch (error) {
+      throw error
+    }
+  }
+
   return {
     getAllTasksByUser,
     createTask,
+    updateTask,
+    getTaskById,
   }
 }

--- a/src/validators/task.validator.js
+++ b/src/validators/task.validator.js
@@ -17,7 +17,20 @@ export function TaskValidator() {
     }
   }
 
+  function validateUpdateTask(updateTaskRequest, taskId) {
+    const { title } = updateTaskRequest
+
+    if (!title) {
+      throw new Error('A task deve possuir um titulo.')
+    }
+
+    if (!taskId) {
+      throw new Error('Deve ser informado o id da task.')
+    }
+  }
+
   return {
     validateCreateTask,
+    validateUpdateTask,
   }
 }


### PR DESCRIPTION
Este PR cria o endpoint para o update de uma task pelo id.

As seguintes alterações foram feitas:

- Adicionado o endpoint para update da task.
- Adicionado dentro da service da task o metodo para buscar um task por id, tendo assim as informações antigas da task. 
- Adicionado no validador de task metodo para validar que foi passado o id da task..
- Adicionado no mapper da task metodo para fazer o mapeamento da request com as informações antigas da task, evitando assim a perce de valores que não precisam ser editados. 