### PR TITLE
Endpoint paginado para busca das tarefas

### DIFF
--- a/src/controller/task.controller.js
+++ b/src/controller/task.controller.js
@@ -33,11 +33,14 @@ export function TaskController() {
   taskController.get('/task/:userId', async (req, res, next) => {
     try {
       const { userId } = req.params
-      const result = await taskService.getAllTasksByUser(userId)
+      const { page, limit } = req.query
+      const result = await taskService.getAllTasksByUserPaginated({
+        userId,
+        page,
+        limit,
+      })
 
-      result.length
-        ? res.status(StatusCodes.OK).json(result)
-        : res.status(StatusCodes.NO_CONTENT)
+      res.status(StatusCodes.OK).json(result)
     } catch (error) {
       next(error)
     }

--- a/src/repository/task.repository.js
+++ b/src/repository/task.repository.js
@@ -29,8 +29,17 @@ export function TaskRepository() {
     await dataBase.parameterQuery(query, params)
   }
 
-  async function getAllTasksByUser(userId) {
-    const query = 'SELECT * FROM task WHERE idUser = ?'
+  async function getAllTasksByUser(userId, offSet, limit) {
+    const query =
+      'SELECT * FROM task WHERE idUser = ? ORDER BY created_at LIMIT ? OFFSET ?'
+    const params = [userId, limit, offSet]
+
+    return await dataBase.parameterQuery(query, params)
+  }
+
+  async function countAllTasksByUserId(userId) {
+    const query =
+      'SELECT COUNT(*) as quantityOfTasks FROM task WHERE idUser = ?'
     const params = [userId]
 
     return await dataBase.parameterQuery(query, params)
@@ -41,5 +50,6 @@ export function TaskRepository() {
     createTask,
     getTaskById,
     updateTask,
+    countAllTasksByUserId,
   }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export { Pagination } from './pagination'

--- a/src/utils/pagination.js
+++ b/src/utils/pagination.js
@@ -1,0 +1,30 @@
+export function Pagination() {
+  function getOffSet(page, limit) {
+    const pageToUse = page - 1
+    const offSet = pageToUse * limit
+
+    return offSet.toString()
+  }
+
+  function buildResponseWithPaginationInfo(
+    response,
+    page,
+    limit,
+    quantityOfItems,
+  ) {
+    const integerPage = parseInt(page)
+    const numberOfElementsReturned = integerPage * limit
+    const hasMoreElements = quantityOfItems > numberOfElementsReturned
+    const quantityOfReturneditems = response.length
+
+    return {
+      page: integerPage,
+      lastPage: !hasMoreElements,
+      limit: limit,
+      quantityOfItems: quantityOfReturneditems,
+      result: response,
+    }
+  }
+
+  return { getOffSet, buildResponseWithPaginationInfo }
+}

--- a/src/validators/task.validator.js
+++ b/src/validators/task.validator.js
@@ -29,8 +29,14 @@ export function TaskValidator() {
     }
   }
 
+  function validateGetTasks(userId) {
+    if (!userId)
+      throw new Error('Deve ser informado o id do usuário vinculado a task')
+  }
+
   return {
     validateCreateTask,
     validateUpdateTask,
+    validateGetTasks,
   }
 }


### PR DESCRIPTION
Este PR altera o endpoint para buscas de tarefas de usuário para que ele seja página e com limite de elementos na busca.

- Criado util de paginação para lidar com o calculo de offSet e do retorno com as informações necessárias para o frontend continuar com a busca páginada.
- Alterado a busca das tasks no repository para que leve em conta o limite e o offSet.
- Criado busca no repository para contar o total de tasks contidas dentro da tabela pelo usuário. Essa informação é necessária para retornar se possuem mais elementos para serem buscados.
