### PR TITLE
Alterar para criar o objeto da data ao criar o tempo da tarefa

### DIFF
--- a/src/mappers/task-time.mapper.js
+++ b/src/mappers/task-time.mapper.js
@@ -1,17 +1,26 @@
 export function TaskTimeMapper() {
   function fromCreateTaskTimeRequestToTaskTime(taskTimeRequest) {
     const { endedAt, initiatedAt } = taskTimeRequest
+    const localeEndedAt = new Date(endedAt).toLocaleString()
+    const localeInitiatedAt = new Date(initiatedAt).toLocaleString()
     const updatedAt = new Date().toLocaleString()
     const createdAt = new Date().toLocaleString()
 
-    return { createdAt, endedAt, initiatedAt, updatedAt }
+    return {
+      initiatedAt: localeInitiatedAt,
+      endedAt: localeEndedAt,
+      createdAt,
+      updatedAt,
+    }
   }
 
   function fromUpdateTaskTimeRequestToTaskTime(updateTaskTimeRequest) {
     const { endedAt, initiatedAt } = updateTaskTimeRequest
+    const localeEndedAt = new Date(endedAt).toLocaleString()
+    const localeInitiatedAt = new Date(initiatedAt).toLocaleString()
     const updatedAt = new Date().toLocaleString()
 
-    return { endedAt, initiatedAt, updatedAt }
+    return { endedAt: localeEndedAt, initiatedAt: localeInitiatedAt, updatedAt }
   }
 
   return {

--- a/src/mappers/task.mapper.js
+++ b/src/mappers/task.mapper.js
@@ -1,8 +1,8 @@
 export function TaskMapper() {
   function fromCreateTaskRequestToTask(taskRequest) {
     const { title, description, link, idUser } = taskRequest
-    const createdAt = new Date()
-    const updatedAt = new Date()
+    const createdAt = new Date().toLocaleString()
+    const updatedAt = new Date().toLocaleString()
     const initiatedAt = new Date(taskRequest.initiatedAt)
     const endedAt = new Date(taskRequest.endedAt)
 

--- a/src/repository/task.repository.js
+++ b/src/repository/task.repository.js
@@ -4,11 +4,11 @@ export function TaskRepository() {
   const dataBase = DataBase()
 
   async function createTask(taskRequest) {
-    const { title, description, link, idUser } = taskRequest
+    const { title, description, link, idUser, createdAt } = taskRequest
     const query =
-      'INSERT INTO task(idUSer, title, description, link) ' +
-      'VALUES (?, ?, ?, ?) '
-    const params = [idUser, title, description, link]
+      'INSERT INTO task(idUSer, title, description, link, createdAt) ' +
+      'VALUES (?, ?, ?, ?, ?) '
+    const params = [idUser, title, description, link, createdAt]
 
     return await dataBase.parameterQuery(query, params)
   }

--- a/src/service/task.service.js
+++ b/src/service/task.service.js
@@ -35,7 +35,7 @@ export function TaskService() {
     const taskEntity = taskMapper.fromCreateTaskRequestToTask(taskRequest)
 
     const createdTask = await taskRepository.createTask(taskEntity)
-    taskTimeService.createTaskTime(taskRequest, createdTask.insertId)
+    await taskTimeService.createTaskTime(taskRequest, createdTask.insertId)
 
     return createdTask.insertId
   }


### PR DESCRIPTION
Este PR irá alterar os mappers da task e taskTime para que usem o toLocaleString:

- Alterado para utiliza o toLocaleString no mapper do taskTime para que o tempo fique no formato correto.
- Alterado para que o mapper da task utiliza o toLocaleString.
- Alterado para que seja populado o createdAt da tabela de task via js.