### PR TITLE
Ajuster endpoint de busca de tarefas

### DIFF
--- a/src/repository/task.repository.js
+++ b/src/repository/task.repository.js
@@ -31,7 +31,7 @@ export function TaskRepository() {
 
   async function getAllTasksByUser(userId, offSet, limit) {
     const query =
-      'SELECT * FROM task WHERE idUser = ? ORDER BY created_at LIMIT ? OFFSET ?'
+      'SELECT * FROM task WHERE idUser = ? ORDER BY createdAt LIMIT ? OFFSET ?'
     const params = [userId, limit, offSet]
 
     return await dataBase.parameterQuery(query, params)


### PR DESCRIPTION
Este PR ajusta o endpoint de busca de tarefas paginadas:

- Ajustado o nome do campo utilizado no order do sql.